### PR TITLE
fix issue if plg have specific client_type

### DIFF
--- a/loader/core/main.py
+++ b/loader/core/main.py
@@ -100,7 +100,11 @@ def init_repos() -> None:
                               f"current: {core_version}")
                     break
 
-                if conf.client_type and conf.client_type.lower() != client_type:
+                if (
+                    conf.client_type
+                    and client_type != "dual"
+                    and conf.client_type.lower() != client_type
+                ):
                     c_type = conf.client_type.lower()
                     reason = f"client type {c_type} is required, current: {client_type}"
                     break


### PR DESCRIPTION
suppose a plugin have bot conversation only like `quotly.py`

then client_type of that plugin is set as `user` and if user using dual mode, plg will not be loaded, 
so this will fix this issue