### PR TITLE
new algo for parsing envs

### DIFF
--- a/loader/core/main.py
+++ b/loader/core/main.py
@@ -126,13 +126,13 @@ def init_repos() -> None:
                 if conf.envs:
                     for env in conf.envs:
                         if '|' in env:
-                            envs = env.split('|')
-                            for e in envs:
-                                if e and os.environ.get(e.strip()):
+                            parts = tuple(filter(None, map(str.strip, env.split('|'))))
+
+                            for part in parts:
+                                if os.environ.get(part):
                                     break
                             else:
-                                reason = f"any one of these envs are required: {env.replace('|', ',')}"
-                            if reason:
+                                reason = f"one of envs {', '.join(parts)} is required"
                                 break
                         else:
                             if not os.environ.get(env):

--- a/loader/core/main.py
+++ b/loader/core/main.py
@@ -125,9 +125,19 @@ def init_repos() -> None:
 
                 if conf.envs:
                     for env in conf.envs:
-                        if not os.environ.get(env):
-                            reason = f"env {env} is required"
-                            break
+                        if '|' in env:
+                            envs = env.split('|')
+                            for e in envs:
+                                if e and os.environ.get(e.strip()):
+                                    break
+                            else:
+                                reason = f"any one of these envs are required: {', '.join(filter(None, envs))}"
+                            if reason:
+                                break
+                        else:
+                            if not os.environ.get(env):
+                                reason = f"env {env} is required"
+                                break
 
                     if reason:
                         break

--- a/loader/core/main.py
+++ b/loader/core/main.py
@@ -131,7 +131,7 @@ def init_repos() -> None:
                                 if e and os.environ.get(e.strip()):
                                     break
                             else:
-                                reason = f"any one of these envs are required: {', '.join(filter(None, envs))}"
+                                reason = f"any one of these envs are required: {env.replace('|', ',')}"
                             if reason:
                                 break
                         else:


### PR DESCRIPTION
Now we can use envs like:

`ENV1 | ENV2 , ENV3 | ENV4`

this is equivalent to 
pair 1 = ENV1 or ENV2 (if not both, plugin will not load)
pair 2 = ENV3 or ENV4 (if not both, plugin will not load)

both pair should have atleast 1 env to load plugin